### PR TITLE
LPD-47024 Search#SearchBlogsScopedToPage

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/NavTab.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/NavTab.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>ACTIVE_TAB_LINK</td>
-	<td>//*[contains(@class,'sr-only') and normalize-space()='${key_tab}'] | //*[contains(@class,'nav-link') and contains(@class,'active') and normalize-space()='${key_tab}'][not(contains(@id,'ProductMenu') or contains(@href,'site_administration'))]</td>
+	<td>//*[contains(@class,'sr-only') and contains(.,'${key_tab}')] | //*[contains(@class,'nav-link') and contains(@class,'active') and contains(.,'${key_tab}')][not(contains(@id,'ProductMenu') or contains(@href,'site_administration'))]</td>
 	<td></td>
 </tr>
 <tr>
@@ -22,7 +22,7 @@
 </tr>
 <tr>
 	<td>TAB_LINK</td>
-	<td>//*[contains(@class,'nav-link') and normalize-space()='${key_tab}'][not(contains(@id,'ProductMenu') or contains(@href,'site_administration'))]</td>
+	<td>//*[contains(@class,'nav-link') and contains(.,'${key_tab}')][not(contains(@id,'ProductMenu') or contains(@href,'site_administration'))]</td>
 	<td></td>
 </tr>
 </tbody>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-47024 - Search#SearchBlogsScopedToPage

This should fix the test by making the locator accept "Scope" for any "Scope Deprecated" tab, however let's run some tests to check if it causes issues with other tests.